### PR TITLE
Maybe its better to raise error on version for versions below 3.0

### DIFF
--- a/autosar/workspace.py
+++ b/autosar/workspace.py
@@ -138,6 +138,8 @@ class Workspace:
         self.release = release
         self.schema = schema
         self.xmlroot = xmlroot
+        if self.version < 3.0:
+            raise NotImplementedError("Version below 3.0 is not implemented")
         if self.packageParser is None:
             self.packageParser = autosar.parser.package_parser.PackageParser(self.version)
         self._registerDefaultElementParsers(self.packageParser)

--- a/autosar/workspace.py
+++ b/autosar/workspace.py
@@ -139,7 +139,7 @@ class Workspace:
         self.schema = schema
         self.xmlroot = xmlroot
         if self.version < 3.0:
-            raise NotImplementedError("Version below 3.0 is not implemented")
+            raise NotImplementedError("Version below 3.0 is not supported")
         if self.packageParser is None:
             self.packageParser = autosar.parser.package_parser.PackageParser(self.version)
         self._registerDefaultElementParsers(self.packageParser)


### PR DESCRIPTION
While trying to open autosar 2.1.2, code fails with error:
return self.switcher.keys()
AttributeError: 'DataTypeParser' object has no attribute 'switcher'
Code flow:
ws.loadXML() => self.openXML(filename) => self._registerDefaultElementParsers(self.packageParser) => parser.registerElementParser(DataTypeParser(self.version)) => registerElementParser(self, elementParser): => getSupportedTags(self):

Maybe its better to raise error on version for versions below 3.0