### PR TITLE
Updating usage of collections for future prof

### DIFF
--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -749,7 +749,7 @@ class InternalBehaviorCommon(Element):
         if exclusiveAreas is not None:
             if isinstance(exclusiveAreas, str):
                 exclusiveAreas =[exclusiveAreas]
-            if isinstance(exclusiveAreas, collections.Iterable):
+            if isinstance(exclusiveAreas, collections.abc.Iterable):
                 for exclusiveAreaName in exclusiveAreas:
                     found = False
                     for exclusiveArea in self.exclusiveAreas:
@@ -1155,7 +1155,7 @@ class InternalBehavior(InternalBehaviorCommon):
             serviceCallPorts=[blockParams['serviceCallPorts']]
         else:
             serviceCallPorts = blockParams['serviceCallPorts']
-        if isinstance(serviceCallPorts, collections.Iterable):
+        if isinstance(serviceCallPorts, collections.abc.Iterable):
             for data in serviceCallPorts:
                 parts = autosar.base.splitRef(data)
                 if len(parts)!=2:

--- a/autosar/component.py
+++ b/autosar/component.py
@@ -68,9 +68,9 @@ class ComponentType(Element):
 
         comspec = kwargs.get('comspec', None)
         if comspec is not None:
-            if isinstance(comspec, collections.Mapping):
+            if isinstance(comspec, collections.abc.Mapping):
                 comspecList = [comspec]
-            elif isinstance(comspec, collections.Iterable):
+            elif isinstance(comspec, collections.abc.Iterable):
                 comspecList = list(comspec)
             else:
                 raise ValueError('comspec argument must be of type dict or list')

--- a/autosar/datatype.py
+++ b/autosar/datatype.py
@@ -510,7 +510,7 @@ class ImplementationDataType(Element):
         self.symbolProps = None
         if isinstance(variantProps, (autosar.base.SwDataDefPropsConditional, autosar.base.SwPointerTargetProps)):
             self.variantProps.append(variantProps)
-        elif isinstance(variantProps, collections.Iterable):
+        elif isinstance(variantProps, collections.abc.Iterable):
             for elem in variantProps:
                 if isinstance(elem, (autosar.base.SwDataDefPropsConditional, autosar.base.SwPointerTargetProps)):
                     self.variantProps.append(elem)
@@ -607,7 +607,7 @@ class ImplementationDataTypeElement(Element):
         if variantProps is not None:
             if isinstance(variantProps, (autosar.base.SwDataDefPropsConditional, autosar.base.SwPointerTargetProps)):
                 self.variantProps.append(variantProps)
-            elif isinstance(variantProps, collections.Iterable):
+            elif isinstance(variantProps, collections.abc.Iterable):
                 for elem in variantProps:
                     if isinstance(elem, (autosar.base.SwDataDefPropsConditional, autosar.base.SwPointerTargetProps)):
                         self.variantProps.append(elem)

--- a/autosar/package.py
+++ b/autosar/package.py
@@ -120,7 +120,7 @@ class Package(object):
 
         portInterface = autosar.portinterface.SenderReceiverInterface(str(name), isService, adminData=adminData)
         if dataElements is not None:
-            if isinstance(dataElements,collections.Iterable):
+            if isinstance(dataElements,collections.abc.Iterable):
                 for elem in dataElements:
                     dataType=ws.find(elem.typeRef, role='DataType')
                     if dataType is None:
@@ -136,7 +136,7 @@ class Package(object):
             else:
                 raise ValueError("dataElements: expected autosar.portinterface.DataElement instance or list")
         if modeGroups is not None:
-            if isinstance(modeGroups,collections.Iterable):
+            if isinstance(modeGroups,collections.abc.Iterable):
                 for elem in modeGroups:
                     portInterface.append(elem)
             elif isinstance(modeGroups,autosar.portinterface.ModeGroup):
@@ -163,7 +163,7 @@ class Package(object):
         if (adminDataObj is not None) and not isinstance(adminDataObj, autosar.base.AdminData):
             raise ValueError("adminData must be of type dict or AdminData")
         portInterface = autosar.portinterface.ParameterInterface(str(name), adminData=adminDataObj)
-        if isinstance(parameters,collections.Iterable):
+        if isinstance(parameters,collections.abc.Iterable):
             for elem in parameters:
                 dataType=ws.find(elem.typeRef, role='DataType')
                 #normalize reference to data element
@@ -390,7 +390,7 @@ class Package(object):
         for name in operations:
             portInterface.append(autosar.portinterface.Operation(name))
         if errors is not None:
-            if isinstance(errors, collections.Iterable):
+            if isinstance(errors, collections.abc.Iterable):
                 for error in errors:
                     portInterface.append(error)
             else:
@@ -505,7 +505,7 @@ class Package(object):
                 elif isinstance(elem, tuple):
                     elemName = elem[0]
                     elemUnitRef = elem[1]
-                elif isinstance(elem, collections.Mapping):
+                elif isinstance(elem, collections.abc.Mapping):
                     elemName = elem['name']
                     elemUnitRef = elem['typeRef']
                 else:
@@ -561,13 +561,13 @@ class Package(object):
                 raise ValueError('initValue: expected type int, got '+str(type(initValue)))
             value=autosar.constant.IntegerValue(name, dataType.ref, initValue)
         elif isinstance(dataType, autosar.datatype.RecordDataType):
-            if isinstance(initValue, collections.Mapping) or isinstance(initValue, collections.Iterable):
+            if isinstance(initValue, collections.abc.Mapping) or isinstance(initValue, collections.abc.Iterable):
                 pass
             else:
                 raise ValueError('initValue: expected type Mapping or Iterable, got '+str(type(initValue)))
             value=self._createRecordValueV3(ws, name, dataType, initValue)
         elif isinstance(dataType, autosar.datatype.ArrayDataType):
-            if isinstance(initValue, collections.Iterable):
+            if isinstance(initValue, collections.abc.Iterable):
                 pass
             else:
                 raise ValueError('initValue: expected type Iterable, got '+str(type(initValue)))
@@ -601,7 +601,7 @@ class Package(object):
 
     def _createRecordValueV3(self, ws, name, dataType, initValue, parent=None):
         value = autosar.constant.RecordValue(name, dataType.ref, parent)
-        if isinstance(initValue, collections.Mapping):
+        if isinstance(initValue, collections.abc.Mapping):
             for elem in dataType.elements:
                 if elem.name in initValue:
                     v = initValue[elem.name]
@@ -613,13 +613,13 @@ class Package(object):
                             raise ValueError('v: expected type int, got '+str(type(v)))
                         value.elements.append(autosar.constant.IntegerValue(elem.name, childType.ref, v, value))
                     elif isinstance(childType, autosar.datatype.RecordDataType):
-                        if isinstance(v, collections.Mapping) or isinstance(v, collections.Iterable):
+                        if isinstance(v, collections.abc.Mapping) or isinstance(v, collections.abc.Iterable):
                             pass
                         else:
                             raise ValueError('v: expected type Mapping or Iterable, got '+str(type(v)))
                         value.elements.append(self._createRecordValueV3(ws, elem.name, childType, v, value))
                     elif isinstance(childType, autosar.datatype.ArrayDataType):
-                        if isinstance(v, collections.Iterable):
+                        if isinstance(v, collections.abc.Iterable):
                             pass
                         else:
                             raise ValueError('v: expected type Iterable, got '+str(type(v)))
@@ -658,7 +658,7 @@ class Package(object):
         childType = ws.find(dataType.typeRef, role='DataType')
         if childType is None:
             raise ValueError('invalid reference: '+str(elem.typeRef))
-        if isinstance(initValue, collections.Iterable):
+        if isinstance(initValue, collections.abc.Iterable):
             for i in range(dataType.length):
                 try:
                     v=initValue[i]
@@ -670,13 +670,13 @@ class Package(object):
                         raise ValueError('v: expected type int, got '+str(type(v)))
                     value.elements.append(autosar.constant.IntegerValue(elemName, childType.ref, v, value))
                 elif isinstance(childType, autosar.datatype.RecordDataType):
-                    if isinstance(v, collections.Mapping) or isinstance(v, collections.Iterable):
+                    if isinstance(v, collections.abc.Mapping) or isinstance(v, collections.abc.Iterable):
                         pass
                     else:
                         raise ValueError('v: expected type Mapping or Iterable, got '+str(type(v)))
                         value.elements.append(self._createRecordValueV3(ws, elemName, childType, v, value))
                 elif isinstance(childType, autosar.datatype.ArrayDataType):
-                    if isinstance(v, collections.Iterable):
+                    if isinstance(v, collections.abc.Iterable):
                         pass
                     else:
                         raise ValueError('v: expected type Iterable, got '+str(type(v)))

--- a/autosar/port.py
+++ b/autosar/port.py
@@ -26,12 +26,12 @@ class Port(Element):
             portInterface=ws.find(portInterfaceRef, role='PortInterface')
             if portInterface is None:
                 raise ValueError("invalid reference: "+portInterfaceRef)
-            if isinstance(comspec, collections.Mapping):
+            if isinstance(comspec, collections.abc.Mapping):
                 comspecObj = self._createComSpecFromDict(ws, portInterface, comspec)
                 if comspecObj is None:
                     raise ValueError('Failed to create comspec from comspec data: '+repr(comspec))
                 self.comspec.append(comspecObj)
-            elif isinstance(comspec, collections.Iterable):
+            elif isinstance(comspec, collections.abc.Iterable):
                 for data in comspec:
                     comspecObj = self._createComSpecFromDict(ws, portInterface, data)
                     if comspecObj is None:

--- a/autosar/portinterface.py
+++ b/autosar/portinterface.py
@@ -238,7 +238,7 @@ class Operation(Element):
         if isinstance(values, str):
             values=[values]
 
-        if isinstance(values, collections.Iterable):
+        if isinstance(values, collections.abc.Iterable):
             del self.errorRefs[:]
             for name in values:
                 found=False

--- a/autosar/writer/package_writer.py
+++ b/autosar/writer/package_writer.py
@@ -39,15 +39,15 @@ class PackageWriter(BaseWriter):
             lines.append(self.indent("<ELEMENTS>",1))
             for elem in package.elements:
                 elemRef = elem.ref
-                ignoreElem=True if (isinstance(ignore, collections.Iterable) and elemRef in ignore) else False
+                ignoreElem=True if (isinstance(ignore, collections.abc.Iterable) and elemRef in ignore) else False
                 #if SWC was ignored by user, also ignore its InternalBehavior and SwcImplementation elements in case they are in the same package
                 if not ignoreElem and isinstance(elem, autosar.behavior.InternalBehavior):
-                    if (isinstance(ignore, collections.Iterable) and elem.componentRef in ignore):
+                    if (isinstance(ignore, collections.abc.Iterable) and elem.componentRef in ignore):
                         ignoreElem = True
                 if not ignoreElem and isinstance(elem, autosar.component.SwcImplementation):
                     behavior = package.rootWS().find(elem.behaviorRef)
                     if behavior is not None:
-                        if (isinstance(ignore, collections.Iterable) and behavior.componentRef in ignore):
+                        if (isinstance(ignore, collections.abc.Iterable) and behavior.componentRef in ignore):
                             ignoreElem = True
                 if not ignoreElem and applyFilter(elemRef, filters):
                     elementName = elem.__class__.__name__
@@ -103,15 +103,15 @@ class PackageWriter(BaseWriter):
                     lines.append('package.createSubPackage("%s")'%(subPackage.name))
         for elem in package.elements:
             elemRef = elem.ref
-            ignoreElem=True if (isinstance(ignore, str) and ignore==elemRef) or (isinstance(ignore, collections.Iterable) and elemRef in ignore) else False
+            ignoreElem=True if (isinstance(ignore, str) and ignore==elemRef) or (isinstance(ignore, collections.abc.Iterable) and elemRef in ignore) else False
 
             #if SWC was ignored by user, also ignore its InternalBehavior and SwcImplementation elements in case they are in the same package
             if not ignoreElem and isinstance(elem, autosar.behavior.InternalBehavior):
-                if (isinstance(ignore, str) and ignore==elem.componentRef) or (isinstance(ignore, collections.Iterable) and elem.componentRef in ignore): ignoreElem = True
+                if (isinstance(ignore, str) and ignore==elem.componentRef) or (isinstance(ignore, collections.abc.Iterable) and elem.componentRef in ignore): ignoreElem = True
             if not ignoreElem and isinstance(elem, autosar.component.SwcImplementation):
                 behavior = package.rootWS().find(elem.behaviorRef)
                 if behavior is not None:
-                    if (isinstance(ignore, str) and ignore==behavior.componentRef) or (isinstance(ignore, collections.Iterable) and behavior.componentRef in ignore): ignoreElem = True
+                    if (isinstance(ignore, str) and ignore==behavior.componentRef) or (isinstance(ignore, collections.abc.Iterable) and behavior.componentRef in ignore): ignoreElem = True
             if not ignoreElem and applyFilter(elemRef, filters):
                 elementName = elem.__class__.__name__
                 elementWriter = self.codeSwitcher.get(elementName)

--- a/autosar/writer/workspace_writer.py
+++ b/autosar/writer/workspace_writer.py
@@ -53,7 +53,7 @@ class WorkspaceWriter(BaseWriter):
         return result+'\n'.join(lines)+'\n'
 
     def toCode(self, ws, filters=None, ignore=None, head=None, tail=None, isModule=False, isTemplate=False, indent=3):
-        localvars = collections.OrderedDict()
+        localvars = collections.abc.OrderedDict()
         localvars['ws']=ws
         indentStr=indent*' '
         if isModule == False:
@@ -94,7 +94,7 @@ class WorkspaceWriter(BaseWriter):
                 ]
             if len(head)!=2:
                 raise ValueError('when module=True then head must have exactly two elements (list of lists)')
-            if isinstance(head[0], collections.Iterable):
+            if isinstance(head[0], collections.abc.Iterable):
                 head[0] = '\n'.join(head[0])
             assert(isinstance(head[0],str))
             result = head[0]+'\n\n'
@@ -109,7 +109,7 @@ class WorkspaceWriter(BaseWriter):
 
             #tail
             result+="\nif __name__=='__main__':\n"
-            if isinstance(head[1], collections.Iterable):
+            if isinstance(head[1], collections.abc.Iterable):
                 head[1] = '\n'.join([indentStr+x for x in head[1]])
             else:
                 head[1] = '\n'.join([indentStr+x for x in head[1].split('\n')])


### PR DESCRIPTION
Changing to use collections.abc.Iterable or collections.abc.Mapping
removes DeprecationWarning about using or importing the ABCs from
'collections'.  Fixes #42 