### PR TITLE
Bug/fix python 3.4 errors

### DIFF
--- a/autosar/util/dcf.py
+++ b/autosar/util/dcf.py
@@ -282,7 +282,7 @@ class Dcf(XMLWriterSimple):
             lines=['<?xml version="1.0" encoding="utf-8"?>']
             if schema is None:
                 #TODO: Below line needs to be improved
-                schema_string = "{0}{1}{2}_DEV".format(*str(self.ws.version).split('.'), self.ws.patch)
+                schema_string = "{0}{1}{patch}_DEV".format(*str(self.ws.version).split('.'), patch=self.ws.patch)
             else:
                 schema_string = schema
             lines.append('<DCF ARSCHEMA="{}">'.format(schema_string))

--- a/autosar/util/dcf.py
+++ b/autosar/util/dcf.py
@@ -282,7 +282,7 @@ class Dcf(XMLWriterSimple):
             lines=['<?xml version="1.0" encoding="utf-8"?>']
             if schema is None:
                 #TODO: Below line needs to be improved
-                schema_string = "{0}{1}{patch}_DEV".format(*str(self.ws.version).split('.'), patch=self.ws.patch)
+                schema_string = "{0}{1}_DEV".format(str(self.ws.version).replace('.',''), self.ws.patch)
             else:
                 schema_string = schema
             lines.append('<DCF ARSCHEMA="{}">'.format(schema_string))

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -105,7 +105,6 @@ class TestBase(unittest.TestCase):
       self.assertEqual(schema, 'AUTOSAR_4-2-2.xsd')
    
    def test_parseAutosarVersionAndSchemaWithReleaseVersion(self):
-      xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00044.xsd"
       xmlData = """<?xml version="1.0" encoding="utf-8"?>
       <AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00044.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       </AUTOSAR>


### PR DESCRIPTION
Fixes syntax errors with older python versions.

Tested on Python 3.4 and 3.8

Solves #47 