### PR TITLE
Removed automatic creation of port API options

### DIFF
--- a/autosar/writer/behavior_writer.py
+++ b/autosar/writer/behavior_writer.py
@@ -59,8 +59,6 @@ class XMLBehaviorWriter(ElementWriter):
             for event in internalBehavior.events:
                 lines.extend(self.indent(self._writeEventXML(ws,event),2))
             lines.append(self.indent('</EVENTS>',1))
-        if len(internalBehavior.portAPIOptions)==0:
-            internalBehavior.createPortAPIOptionDefaults() #try to automatically create PortAPIOption objects on behavior object
         if isinstance(internalBehavior, autosar.behavior.InternalBehavior) and len(internalBehavior.perInstanceMemories)>0:
             lines.append(self.indent('<PER-INSTANCE-MEMORYS>',1))
             for memory in internalBehavior.perInstanceMemories:

--- a/tests/arxml/ar3_component_test.py
+++ b/tests/arxml/ar3_component_test.py
@@ -36,6 +36,7 @@ class ARXML3ComponentTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc = package.createApplicationSoftwareComponent('MyApplication')
         swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc.behavior.createPortAPIOptionDefaults()
         file_name = 'ar3_application_component.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
@@ -47,6 +48,7 @@ class ARXML3ComponentTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc = package.createServiceComponent('MyService')
         swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc.behavior.createPortAPIOptionDefaults()
         file_name = 'ar3_service_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
@@ -58,6 +60,7 @@ class ARXML3ComponentTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc = package.createComplexDeviceDriverComponent('MyComplexDeviceDriver')
         swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc.behavior.createPortAPIOptionDefaults()
         file_name = 'ar3_cdd_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)

--- a/tests/arxml/ar4_behavior_test.py
+++ b/tests/arxml/ar4_behavior_test.py
@@ -98,6 +98,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         swc1 = ws['ComponentTypes'].createApplicationSoftwareComponent('MyApplication')
         swc1.behavior.createRunnable('MyApplication_Init')
         swc1.behavior.createInitEvent('MyApplication_Init')
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_with_init_event.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -115,6 +116,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         swc1.createRequirePort('VehicleMode', '/PortInterfaces/VehicleMode_I')
         swc1.behavior.createRunnable('MyApplication_Init')
         swc1.behavior.createModeSwitchEvent('MyApplication_Init', 'VehicleMode/ACCESSORY', activationType='ENTRY')
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_with_require_type_mode_switch_trigger.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -131,6 +133,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         swc1 = ws['ComponentTypes'].createApplicationSoftwareComponent('MyApplication')
         port1 = swc1.createRequirePort('VehicleMode', '/PortInterfaces/VehicleMode_I')
         runnable1 = swc1.behavior.createRunnable('MyApplication_Run', portAccess='VehicleMode')
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_runnable_require_type_mode_access.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -154,6 +157,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         swc1 = ws['ComponentTypes'].createApplicationSoftwareComponent('MyApplication')
         port1 = swc1.createProvidePort('VehicleMode', '/PortInterfaces/VehicleMode_I', queueLength=1, modeSwitchAckTimeout=10)
         runnable1 = swc1.behavior.createRunnable('MyApplication_Init', portAccess=['VehicleMode'])
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_with_provide_type_mode_access.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -178,6 +182,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         port1 = swc1.createProvidePort('VehicleMode', '/PortInterfaces/VehicleMode_I', queueLength=1, modeSwitchAckTimeout=10)
         runnable1 = swc1.behavior.createRunnable('MyApplication_SetVehicleMode', portAccess=['VehicleMode'], modeSwitchPoint=['VehicleMode'])
         self.assertEqual(len(runnable1.modeSwitchPoints), 1)
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_with_provide_type_mode_switch_point.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -206,6 +211,7 @@ class ARXML4BehaviorTest(ARXMLTestClass):
         ackRunnable1 = swc1.behavior.createRunnable('MyApplication_VehicleModeSwitchAck', portAccess=['VehicleMode'])
         swc1.behavior.createModeSwitchAckEvent(ackRunnable1.name, switchRunnable1.name)
         self.assertEqual(len(swc1.behavior.events), 1)
+        swc1.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_runnable_with_mode_switch_ack_event_trigger.arxml'
         generated_file = os.path.join(self.output_dir, file_name)

--- a/tests/arxml/ar4_component_test.py
+++ b/tests/arxml/ar4_component_test.py
@@ -75,6 +75,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc = package.createApplicationSoftwareComponent('MyApplication')
         swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
         swc.createRequirePort('FreeRunningTimer', 'FreeRunningTimer5ms_I')
+        swc.behavior.createPortAPIOptionDefaults()
         swc.behavior.createRunnable('Run', portAccess=['VehicleSpeed', 'FreeRunningTimer/GetTime', 'FreeRunningTimer/IsTimerElapsed'])
         swc.behavior.createTimerEvent('Run', 20) #execute the Run function every 20ms in all modes
         file_name = 'ar4_application_swc.arxml'
@@ -88,6 +89,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc = package.createServiceComponent('MyService')
         swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_service_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
@@ -99,6 +101,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         package = ws1.find('/ComponentTypes')
         swc1 = package.createComplexDeviceDriverComponent('MyService')
         swc1.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc1.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_cdd_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
@@ -128,6 +131,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         inner_swc = package.createApplicationSoftwareComponent('MyApplication')
         inner_port = inner_swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
         inner_swc.createRequirePort('FreeRunningTimer', 'FreeRunningTimer5ms_I')
+        inner_swc.behavior.createPortAPIOptionDefaults()
         outer_swc = package.createCompositionComponent('MyComposition')
         outer_swc.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
         outer_swc.createComponentPrototype(inner_swc.ref)
@@ -151,6 +155,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc.behavior.createRunnable('FrtServer_FreeRunningTimer5ms_IsTimerElapsed')
         swc.behavior.createOperationInvokedEvent('FrtServer_FreeRunningTimer5ms_GetTime', 'FreeRunningTimer5ms/GetTime')
         swc.behavior.createOperationInvokedEvent('FrtServer_FreeRunningTimer5ms_IsTimerElapsed', 'FreeRunningTimer5ms/IsTimerElapsed')
+        swc.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_server_component.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -167,6 +172,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc = package.createApplicationSoftwareComponent('ButtonPressHandler')
         swc.createProvidePort('ButtonPressUp', 'PushButtonStatus_I')
         swc.createProvidePort('ButtonPressDown', 'PushButtonStatus_I')
+        swc.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_swc_with_queued_sender_com_spec.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -183,6 +189,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc = package.createApplicationSoftwareComponent('ButtonPressListener')
         swc.createRequirePort('ButtonPressUp', 'PushButtonStatus_I', queueLength=10)
         swc.createRequirePort('ButtonPressDown', 'PushButtonStatus_I', queueLength=10)
+        swc.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_swc_with_queued_receiver_com_spec.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -215,6 +222,7 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc.createRequirePort('LastCyclePushButtonStatus_2_NvR', 'LastCyclePushButtonStatus_NvI', initValue = initValue.value)
         swc.createRequirePort('RebootCount_NvR', 'RebootCount_NvI', initValue = int(1))
         swc.createProvidePort('RebootCount_NvW', 'RebootCount_NvI', ramBlockInitValue = int(2), romBlockInitValue = int(3))
+        swc.behavior.createPortAPIOptionDefaults()
         swc.behavior.createRunnable('run', portAccess=['LastCyclePushButtonStatus_1_NvR/LastCyclePushButtonStatus', 'LastCyclePushButtonStatus_1_NvW/LastCyclePushButtonStatus'])
         swc.behavior.createTimingEvent('run', 20) #execute the run function every 20ms in all modes
         file_name_generated = 'ar4_swc_with_nvdata_ports_generated.arxml'
@@ -356,6 +364,8 @@ class ARXML4ComponentTest(ARXMLTestClass):
 
         swc.behavior.createRunnable('RebootCount_Received', portAccess=['EcuStatus/RebootCount'], minStartInterval=5)
         swc.behavior.createDataReceivedEvent('RebootCount_Received', 'EcuStatus/RebootCount')
+
+        swc.behavior.createPortAPIOptionDefaults()
 
         file_name = 'ar4_application_swc_data_received_event.arxml'
         generated_file = os.path.join(self.output_dir, file_name)

--- a/tests/arxml/ar4_port_test.py
+++ b/tests/arxml/ar4_port_test.py
@@ -62,6 +62,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         swc1.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', comspec = {'dataElement': 'VehicleSpeed', 'initValueRef': 'VehicleSpeed_IV'})
+        swc1.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_non_queued_receiver_port_single_data_element_direct_comspec1.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'port', file_name)
@@ -80,6 +81,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         swc1.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', comspec = {'initValueRef': 'VehicleSpeed_IV'})
+        swc1.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_non_queued_receiver_port_single_data_element_direct_comspec2.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'port', file_name)
@@ -95,6 +97,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         swc1.createRequirePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc1.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_non_queued_receiver_port_single_data_element.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'port', file_name)
@@ -110,6 +113,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         port1 = swc1.createRequirePort('VehicleMode', 'VehicleMode_I')
+        swc1.behavior.createPortAPIOptionDefaults()
         self.assertEqual(port1.portInterfaceRef, '/PortInterfaces/VehicleMode_I')
         comspec1 = port1.comspec[0]
         comspec1.modeGroupRef = '/PortInterfaces/VehicleMode_I/mode'
@@ -128,6 +132,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         port1 = swc1.createProvidePort('VehicleMode', 'VehicleMode_I', modeGroup="mode", queueLength=1, modeSwitchAckTimeout=10)
+        swc1.behavior.createPortAPIOptionDefaults()
         self.assertEqual(port1.portInterfaceRef, '/PortInterfaces/VehicleMode_I')
         file_name = 'ar4_mode_provide_port.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
@@ -150,6 +155,7 @@ class ARXML4PortCreateTest(ARXMLTestClass):
         package = ws.find('/ComponentTypes')
         swc1 = package.createApplicationSoftwareComponent('MyApplication')
         swc1.createProvidePort('VehicleSpeed', 'VehicleSpeed_I', initValueRef = 'VehicleSpeed_IV')
+        swc1.behavior.createPortAPIOptionDefaults()
         file_name = 'ar4_non_queued_sender_port_single_data_element.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'port', file_name)

--- a/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
@@ -75,23 +75,6 @@
                   </DATA-IREF>
                 </DATA-RECEIVED-EVENT>
               </EVENTS>
-              <PORT-API-OPTIONS>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/LastCyclePushButtonStatus_NvR</PORT-REF>
-                </PORT-API-OPTION>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/RebootCount_NvR</PORT-REF>
-                </PORT-API-OPTION>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/UserSetting_NvR</PORT-REF>
-                </PORT-API-OPTION>
-              </PORT-API-OPTIONS>
               <RUNNABLES>
                 <RUNNABLE-ENTITY>
                   <SHORT-NAME>run</SHORT-NAME>


### PR DESCRIPTION
SWC port API options is not always used and the automatic creation of
default port API options causes it to be added even when not used.