### PR TITLE
Disabled automatic creation of port API options for NvBlockComponent

### DIFF
--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -639,6 +639,7 @@ class InternalBehaviorCommon(Element):
         self.multipleInstance = bool(multipleInstance)
         self.events = []
         self.portAPIOptions = []
+        self.autoCreatePortAPIOptions = False
         self.runnables = []
         self.exclusiveAreas=[]
         self.perInstanceMemories = []

--- a/autosar/package.py
+++ b/autosar/package.py
@@ -309,7 +309,7 @@ class Package(object):
         return autosar.base.indexByName(lst,name)
 
 
-    def createApplicationSoftwareComponent(self, swcName, behaviorName=None, implementationName=None, multipleInstance=False):
+    def createApplicationSoftwareComponent(self, swcName, behaviorName=None, implementationName=None, multipleInstance=False, autoCreatePortAPIOptions=True):
         """
         Creates a new ApplicationSoftwareComponent object and adds it to the package.
         It also creates an InternalBehavior object as well as an SwcImplementation object.
@@ -319,11 +319,11 @@ class Package(object):
         assert(ws is not None)
         swc = autosar.component.ApplicationSoftwareComponent(swcName,self)
         self.append(swc)
-        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance)
+        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance, autoCreatePortAPIOptions)
         self._createImplementation(swc, implementationName)
         return swc
 
-    def createServiceComponent(self, swcName, behaviorName=None, implementationName=None, multipleInstance=False):
+    def createServiceComponent(self, swcName, behaviorName=None, implementationName=None, multipleInstance=False, autoCreatePortAPIOptions=True):
         """
         Creates a new ApplicationSoftwareComponent object and adds it to the package.
         It also creates an InternalBehavior object as well as an SwcImplementation object.
@@ -333,20 +333,20 @@ class Package(object):
 
         swc = autosar.component.ServiceComponent(swcName,self)
         self.append(swc)
-        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance)
+        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance, autoCreatePortAPIOptions)
         self._createImplementation(swc, implementationName)
         return swc
 
-    def createComplexDeviceDriverComponent(self,swcName,behaviorName=None,implementationName=None,multipleInstance=False):
+    def createComplexDeviceDriverComponent(self,swcName,behaviorName=None,implementationName=None,multipleInstance=False, autoCreatePortAPIOptions=True):
         ws = self.rootWS()
         assert(ws is not None)
         swc=autosar.component.ComplexDeviceDriverComponent(swcName, parent=self)
         self.append(swc)
-        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance)
+        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance, autoCreatePortAPIOptions)
         self._createImplementation(swc, implementationName)
         return swc
 
-    def createNvBlockComponent(self,swcName,behaviorName=None,implementationName=None,multipleInstance=False):
+    def createNvBlockComponent(self,swcName,behaviorName=None,implementationName=None,multipleInstance=False, autoCreatePortAPIOptions=False):
         """
         Creates a new NvBlockComponent object and adds it to the package.
         It also creates an InternalBehavior object as well as an SwcImplementation object.
@@ -356,7 +356,7 @@ class Package(object):
         assert(ws is not None)
         swc = autosar.component.NvBlockComponent(swcName,self)
         self.append(swc)
-        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance)
+        self._createInternalBehavior(ws, swc, behaviorName, multipleInstance, autoCreatePortAPIOptions)
         self._createImplementation(swc, implementationName)
         return swc
 
@@ -365,7 +365,7 @@ class Package(object):
         self.append(component)
         return component
 
-    def _createInternalBehavior(self, ws, swc, behaviorName, multipleInstance):
+    def _createInternalBehavior(self, ws, swc, behaviorName, multipleInstance, autoCreatePortAPIOptions):
         """
         Initializes swc.behavior object
         For AUTOSAR3, an instance of InternalBehavior is created
@@ -379,6 +379,7 @@ class Package(object):
         else:
             # In AUTOSAR 4.x the internal behavior is a sub-element of the swc.
             internalBehavior = autosar.behavior.SwcInternalBehavior(behaviorName,swc.ref,multipleInstance, swc)
+        internalBehavior.autoCreatePortAPIOptions=autoCreatePortAPIOptions
         swc.behavior=internalBehavior
         if ws.version < 4.0:
             # In AUTOSAR 3.x the internal behavior is a sub-element of the package.

--- a/autosar/writer/behavior_writer.py
+++ b/autosar/writer/behavior_writer.py
@@ -59,7 +59,7 @@ class XMLBehaviorWriter(ElementWriter):
             for event in internalBehavior.events:
                 lines.extend(self.indent(self._writeEventXML(ws,event),2))
             lines.append(self.indent('</EVENTS>',1))
-        if len(internalBehavior.portAPIOptions)==0:
+        if len(internalBehavior.portAPIOptions) == 0 and (internalBehavior.autoCreatePortAPIOptions):
             internalBehavior.createPortAPIOptionDefaults() #try to automatically create PortAPIOption objects on behavior object
         if isinstance(internalBehavior, autosar.behavior.InternalBehavior) and len(internalBehavior.perInstanceMemories)>0:
             lines.append(self.indent('<PER-INSTANCE-MEMORYS>',1))

--- a/doc/autosar4_api/package.rst
+++ b/doc/autosar4_api/package.rst
@@ -155,6 +155,7 @@ createApplicationSoftwareComponent
     :param str behaviorName: ShortName of the associated Behavior object. If not set an automatic name is selected.
     :param str implementationName: ShortName of the associated Implementation object. If not set an automatic name is selected.
     :param bool multipleInstance: Set to True if this component prototype needs to support multiple instances
+    :param bool autoCreatePortAPIOptions: Set to True to automatically create port API options.
     :rtype: :ref:`ar4_component_ApplicationSoftwareComponent`
 
 Example
@@ -176,6 +177,7 @@ createComplexDeviceDriverComponent
     :param str behaviorName: ShortName of the associated Behavior object. If not set an automatic name is selected.
     :param str implementationName: ShortName of the associated Implementation object. If not set an automatic name is selected.
     :param bool multipleInstance: Set to True if this component prototype needs to support multiple instances
+    :param bool autoCreatePortAPIOptions: Set to True to automatically create port API options.
     :rtype: :ref:`ar4_component_ComplexDeviceDriverComponent`
 
 .. _ar4_package_Package_createCompositionComponent:
@@ -210,6 +212,7 @@ createNvBlockComponent
     :param str behaviorName: ShortName of the associated Behavior object. If not set an automatic name is selected.
     :param str implementationName: ShortName of the associated Implementation object. If not set an automatic name is selected.
     :param bool multipleInstance: Set to True if this component prototype needs to support multiple instances
+    :param bool autoCreatePortAPIOptions: Set to True to automatically create port API options.
     :rtype: NvBlockComponent
 
 .. _ar4_package_Package_createServiceComponent:
@@ -225,6 +228,7 @@ createServiceComponent
     :param str behaviorName: ShortName of the associated Behavior object. If not set an automatic name is selected.
     :param str implementationName: ShortName of the associated Implementation object. If not set an automatic name is selected.
     :param bool multipleInstance: Set to True if this component prototype needs to support multiple instances.
+    :param bool autoCreatePortAPIOptions: Set to True to automatically create port API options.
     :rtype: :ref:`ar4_component_ServiceComponent`
 
 Example

--- a/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
@@ -75,23 +75,6 @@
                   </DATA-IREF>
                 </DATA-RECEIVED-EVENT>
               </EVENTS>
-              <PORT-API-OPTIONS>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/LastCyclePushButtonStatus_NvR</PORT-REF>
-                </PORT-API-OPTION>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/RebootCount_NvR</PORT-REF>
-                </PORT-API-OPTION>
-                <PORT-API-OPTION>
-                  <ENABLE-TAKE-ADDRESS>false</ENABLE-TAKE-ADDRESS>
-                  <INDIRECT-API>false</INDIRECT-API>
-                  <PORT-REF DEST="R-PORT-PROTOTYPE">/ComponentTypes/NvBlockHandler/UserSetting_NvR</PORT-REF>
-                </PORT-API-OPTION>
-              </PORT-API-OPTIONS>
               <RUNNABLES>
                 <RUNNABLE-ENTITY>
                   <SHORT-NAME>run</SHORT-NAME>


### PR DESCRIPTION
SWC port API options is not always used and the automatic creation of
default port API options causes it to be added even when not used.

This support can be used in all SWC types by setting the parameter
autoCreatePortAPIOptions to false.