### PR TITLE
Cleanup in package.py

### DIFF
--- a/autosar/package.py
+++ b/autosar/package.py
@@ -389,26 +389,9 @@ class Package(object):
 
     def _createImplementation(self, swc, implementationName):
 
-        ws = self.rootWS()
-        assert(ws is not None)
         if implementationName is None:
             implementationName = swc.name+'_Implementation'
         swc.implementation = autosar.component.SwcImplementation(implementationName, swc.behavior.ref, parent=self)
-
-        name = 'Default' if ws.version >= 4.0 else 'Code'
-        codeDescriptor = autosar.component.SwcImplementationCodeDescriptor(name, swc.implementation)
-
-        if ws.version >= 4.0:
-            engineeringObject = autosar.component.EngineeringObject(codeDescriptor)
-            engineeringObject.shortLabel = 'Default'
-            engineeringObject.category   = 'SWSRC'
-            codeDescriptor.artifactDescriptors = []
-            codeDescriptor.artifactDescriptors.append(engineeringObject)
-        else:
-            codeDescriptor.type = 'SRC'
-
-        swc.implementation.codeDescriptors = []
-        swc.implementation.codeDescriptors.append(codeDescriptor)
 
         self.append(swc.implementation)
 

--- a/tests/arxml/ar3_component_test.py
+++ b/tests/arxml/ar3_component_test.py
@@ -50,7 +50,7 @@ class ARXML3ComponentTest(ARXMLTestClass):
         file_name = 'ar3_service_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
-        self.save_and_check(ws, expected_file, generated_file, ['/ComponentTypes'])        
+        self.save_and_check(ws, expected_file, generated_file, ['/ComponentTypes'])
 
     def test_create_cdd_software_component(self):
         ws = autosar.workspace(version="3.0.2")
@@ -61,7 +61,7 @@ class ARXML3ComponentTest(ARXMLTestClass):
         file_name = 'ar3_cdd_swc.arxml'
         generated_file = os.path.join(self.output_dir, file_name)
         expected_file = os.path.join( 'expected_gen', 'component', file_name)
-        self.save_and_check(ws, expected_file, generated_file, ['/ComponentTypes'])          
+        self.save_and_check(ws, expected_file, generated_file, ['/ComponentTypes'])
         generated_file = os.path.join(_output_dir, 'ar3_cdd_swc.arxml')
 
 if __name__ == '__main__':

--- a/tests/arxml/ar4_swc_implementation_test.py
+++ b/tests/arxml/ar4_swc_implementation_test.py
@@ -57,8 +57,22 @@ class ARXML4ComponentTest(ARXMLTestClass):
         swc.createRequirePort('FreeRunningTimer', 'FreeRunningTimer5ms_I')
         swc.behavior.createRunnable('Run', portAccess=['FreeRunningTimer/GetTime', 'FreeRunningTimer/IsTimerElapsed'])
         swc.behavior.createTimerEvent('Run', 20) #execute the Run function every 20ms in all modes
-        swc.implementation.codeDescriptors[0].artifactDescriptors[0].revisionLabels = ['1.0.1']
-        swc.implementation.codeDescriptors[0].artifactDescriptors[0].domain = 'testDomain'
+        codeDescriptor = autosar.component.SwcImplementationCodeDescriptor('Code', swc.implementation)
+        codeDescriptor.artifactDescriptors = []
+        engineeringObject = autosar.component.EngineeringObject(codeDescriptor)
+        engineeringObject.shortLabel = 'MyApplication.c'
+        engineeringObject.category   = 'SWSRC'
+        engineeringObject.revisionLabels = ['1.0.1']
+        engineeringObject.domain = 'testDomain'
+        codeDescriptor.artifactDescriptors.append(engineeringObject)
+        engineeringObject = autosar.component.EngineeringObject(codeDescriptor)
+        engineeringObject.shortLabel = 'MyApplication.h'
+        engineeringObject.category   = 'SWSRC'
+        engineeringObject.revisionLabels = ['1.0.2']
+        engineeringObject.domain = 'testDomain'
+        codeDescriptor.artifactDescriptors.append(engineeringObject)
+        swc.implementation.codeDescriptors = []
+        swc.implementation.codeDescriptors.append(codeDescriptor)
         swc.implementation.programmingLanguage = 'C'
         swc.implementation.swVersion = '1.0.0'
         swc.implementation.useCodeGenerator = 'codeGen'

--- a/tests/arxml/expected_gen/behavior/ar4_behavior_empty_from_swc.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_behavior_empty_from_swc.arxml
@@ -17,17 +17,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_runnable_require_type_mode_access.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_runnable_require_type_mode_access.arxml
@@ -52,17 +52,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_with_init_event.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_with_init_event.arxml
@@ -31,17 +31,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_with_mode_switch_ack_event_trigger.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_with_mode_switch_ack_event_trigger.arxml
@@ -77,17 +77,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_with_provide_type_mode_access.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_with_provide_type_mode_access.arxml
@@ -55,17 +55,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_with_provide_type_mode_switch_point.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_with_provide_type_mode_switch_point.arxml
@@ -64,17 +64,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/behavior/ar4_runnable_with_require_type_mode_switch_trigger.arxml
+++ b/tests/arxml/expected_gen/behavior/ar4_runnable_with_require_type_mode_switch_trigger.arxml
@@ -56,17 +56,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar3_application_component.arxml
+++ b/tests/arxml/expected_gen/component/ar3_application_component.arxml
@@ -34,12 +34,6 @@
 				</INTERNAL-BEHAVIOR>
 				<SWC-IMPLEMENTATION>
 					<SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-					<CODE-DESCRIPTORS>
-						<CODE>
-							<SHORT-NAME>Code</SHORT-NAME>
-							<TYPE>SRC</TYPE>
-						</CODE>
-					</CODE-DESCRIPTORS>
 					<BEHAVIOR-REF DEST="INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication_InternalBehavior</BEHAVIOR-REF>
 				</SWC-IMPLEMENTATION>
 			</ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar3_cdd_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar3_cdd_swc.arxml
@@ -34,12 +34,6 @@
 				</INTERNAL-BEHAVIOR>
 				<SWC-IMPLEMENTATION>
 					<SHORT-NAME>MyComplexDeviceDriver_Implementation</SHORT-NAME>
-					<CODE-DESCRIPTORS>
-						<CODE>
-							<SHORT-NAME>Code</SHORT-NAME>
-							<TYPE>SRC</TYPE>
-						</CODE>
-					</CODE-DESCRIPTORS>
 					<BEHAVIOR-REF DEST="INTERNAL-BEHAVIOR">/ComponentTypes/MyComplexDeviceDriver_InternalBehavior</BEHAVIOR-REF>
 				</SWC-IMPLEMENTATION>
 			</ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar3_service_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar3_service_swc.arxml
@@ -35,12 +35,6 @@
 				</INTERNAL-BEHAVIOR>
 				<SWC-IMPLEMENTATION>
 					<SHORT-NAME>MyService_Implementation</SHORT-NAME>
-					<CODE-DESCRIPTORS>
-						<CODE>
-							<SHORT-NAME>Code</SHORT-NAME>
-							<TYPE>SRC</TYPE>
-						</CODE>
-					</CODE-DESCRIPTORS>
 					<BEHAVIOR-REF DEST="INTERNAL-BEHAVIOR">/ComponentTypes/MyService_InternalBehavior</BEHAVIOR-REF>
 				</SWC-IMPLEMENTATION>
 			</ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_application_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_application_swc.arxml
@@ -106,17 +106,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_application_swc_data_received_event.arxml
+++ b/tests/arxml/expected_gen/component/ar4_application_swc_data_received_event.arxml
@@ -265,17 +265,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_cdd_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_cdd_swc.arxml
@@ -45,17 +45,6 @@
         </COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyService_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyService/MyService_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_composition_with_one_inner_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_composition_with_one_inner_swc.arxml
@@ -62,17 +62,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
         <COMPOSITION-SW-COMPONENT-TYPE>

--- a/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_nvblock_swc.arxml
@@ -303,17 +303,6 @@
         </NV-BLOCK-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>NvBlockHandler_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/NvBlockHandler/NvBlockHandler_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_server_component.arxml
+++ b/tests/arxml/expected_gen/component/ar4_server_component.arxml
@@ -70,17 +70,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>FrtServer_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/FrtServer/FrtServer_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_service_swc.arxml
+++ b/tests/arxml/expected_gen/component/ar4_service_swc.arxml
@@ -46,17 +46,6 @@
         </SERVICE-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyService_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyService/MyService_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_swc_implementation.arxml
+++ b/tests/arxml/expected_gen/component/ar4_swc_implementation.arxml
@@ -71,13 +71,21 @@
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
           <CODE-DESCRIPTORS>
             <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
+              <SHORT-NAME>Code</SHORT-NAME>
               <ARTIFACT-DESCRIPTORS>
                 <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
+                  <SHORT-LABEL>MyApplication.c</SHORT-LABEL>
                   <CATEGORY>SWSRC</CATEGORY>
                   <REVISION-LABELS>
                     <REVISION-LABEL>1.0.1</REVISION-LABEL>
+                  </REVISION-LABELS>
+                  <DOMAIN>testDomain</DOMAIN>
+                </AUTOSAR-ENGINEERING-OBJECT>
+                <AUTOSAR-ENGINEERING-OBJECT>
+                  <SHORT-LABEL>MyApplication.h</SHORT-LABEL>
+                  <CATEGORY>SWSRC</CATEGORY>
+                  <REVISION-LABELS>
+                    <REVISION-LABEL>1.0.2</REVISION-LABEL>
                   </REVISION-LABELS>
                   <DOMAIN>testDomain</DOMAIN>
                 </AUTOSAR-ENGINEERING-OBJECT>

--- a/tests/arxml/expected_gen/component/ar4_swc_implementation_memmap.arxml
+++ b/tests/arxml/expected_gen/component/ar4_swc_implementation_memmap.arxml
@@ -69,17 +69,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <PROGRAMMING-LANGUAGE>C</PROGRAMMING-LANGUAGE>
           <RESOURCE-CONSUMPTION>
             <SHORT-NAME>RsrcCons_MyApplication</SHORT-NAME>

--- a/tests/arxml/expected_gen/component/ar4_swc_with_nvdata_ports.arxml
+++ b/tests/arxml/expected_gen/component/ar4_swc_with_nvdata_ports.arxml
@@ -192,17 +192,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>ButtonPressListener_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/ButtonPressListener/ButtonPressListener_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_swc_with_queued_receiver_com_spec.arxml
+++ b/tests/arxml/expected_gen/component/ar4_swc_with_queued_receiver_com_spec.arxml
@@ -49,17 +49,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>ButtonPressListener_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/ButtonPressListener/ButtonPressListener_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/component/ar4_swc_with_queued_sender_com_spec.arxml
+++ b/tests/arxml/expected_gen/component/ar4_swc_with_queued_sender_com_spec.arxml
@@ -47,17 +47,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>ButtonPressHandler_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/ButtonPressHandler/ButtonPressHandler_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_mode_provide_port.arxml
+++ b/tests/arxml/expected_gen/port/ar4_mode_provide_port.arxml
@@ -38,17 +38,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_mode_require_port.arxml
+++ b/tests/arxml/expected_gen/port/ar4_mode_require_port.arxml
@@ -35,17 +35,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element.arxml
+++ b/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element.arxml
@@ -45,17 +45,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element_direct_comspec1.arxml
+++ b/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element_direct_comspec1.arxml
@@ -45,17 +45,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element_direct_comspec2.arxml
+++ b/tests/arxml/expected_gen/port/ar4_non_queued_receiver_port_single_data_element_direct_comspec2.arxml
@@ -45,17 +45,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>

--- a/tests/arxml/expected_gen/port/ar4_non_queued_sender_port_single_data_element.arxml
+++ b/tests/arxml/expected_gen/port/ar4_non_queued_sender_port_single_data_element.arxml
@@ -39,17 +39,6 @@
         </APPLICATION-SW-COMPONENT-TYPE>
         <SWC-IMPLEMENTATION>
           <SHORT-NAME>MyApplication_Implementation</SHORT-NAME>
-          <CODE-DESCRIPTORS>
-            <CODE>
-              <SHORT-NAME>Default</SHORT-NAME>
-              <ARTIFACT-DESCRIPTORS>
-                <AUTOSAR-ENGINEERING-OBJECT>
-                  <SHORT-LABEL>Default</SHORT-LABEL>
-                  <CATEGORY>SWSRC</CATEGORY>
-                </AUTOSAR-ENGINEERING-OBJECT>
-              </ARTIFACT-DESCRIPTORS>
-            </CODE>
-          </CODE-DESCRIPTORS>
           <BEHAVIOR-REF DEST="SWC-INTERNAL-BEHAVIOR">/ComponentTypes/MyApplication/MyApplication_InternalBehavior</BEHAVIOR-REF>
         </SWC-IMPLEMENTATION>
       </ELEMENTS>


### PR DESCRIPTION
Removed automatic creation of a default code descriptor. This is not needed and can be removed.

This change causes an update in multiple arxml files in expected_gen, there the default code descriptor is removed.

In one file is code descriptor handling tested and that test is extended with two descriptors.

All tests passes and the arxml files in expected_gen passes schema validation tests.