### PR TITLE
Add admin data for software component

### DIFF
--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -109,7 +109,9 @@ class ComponentTypeParser(ElementParser):
             raise NotImplementedError(xmlRoot.tag)
         for xmlElem in xmlRoot.findall('./*'):
             if xmlElem.tag not in handledTags:
-                if (xmlElem.tag == 'ADMIN-DATA') or (xmlElem.tag == 'DESC'):
+                if xmlElem.tag == 'ADMIN-DATA':
+                    componentType.adminData = self.parseAdminDataNode(xmlElem)
+                elif xmlElem.tag == 'DESC':
                     pass #Implement later
                 elif xmlElem.tag == 'PORTS':
                     self.parseComponentPorts(componentType,xmlRoot)

--- a/autosar/writer/component_writer.py
+++ b/autosar/writer/component_writer.py
@@ -81,6 +81,8 @@ class XMLComponentTypeWriter(ElementWriter):
         lines.append(self.indent('<SHORT-NAME>%s</SHORT-NAME>'%swc.name,1))
         if isinstance(swc, autosar.component.ServiceComponent):
             lines.append(self.indent('<CATEGORY>ServiceComponent</CATEGORY>',1))
+        if swc.adminData is not None:
+            lines.extend(self.indent(self.writeAdminDataXML(swc.adminData),1))
         descLines = self.writeDescXML(swc)
         if descLines is not None:
             lines.extend(self.indent(descLines,1))


### PR DESCRIPTION
With those changes, admin data for software components will be read from the ARXML file into the workspace and also will be written back from the workspace into the file.